### PR TITLE
docs(Práctica1): Actualizar documentación para que coincida con los tests

### DIFF
--- a/Practica1/README.md
+++ b/Practica1/README.md
@@ -162,7 +162,7 @@ file (thus indicating you no longer need to read from it).
   and return 0. Note that this is slightly different than the behavior of 
   normal UNIX **cat** (if you'd like to, figure out the difference).
 * If the program tries to **fopen()** a file and fails, it should print the
-  exact message "UVacat: cannot open file" (followed by a newline) and exit
+  exact message "UVacat: no puedo abrir fichero" (followed by a newline) and exit
   with status code 1.  If multiple files are specified on the command line,
   the files should be printed out in order until the end of the file list is
   reached or an error opening a file is reached (at which point the error


### PR DESCRIPTION
Los tests muestran error cuando el programa escribe `"UVacat: cannot open file"`, esa parte de la documentación no está traducida.